### PR TITLE
Fix api-reference/muuricomponent.mdx onSort onFilter sample code 

### DIFF
--- a/website/docs/api-reference/muuricomponent.mdx
+++ b/website/docs/api-reference/muuricomponent.mdx
@@ -1085,7 +1085,7 @@ Triggered when the `filter` is applied.
 
 ```jsx
 <MuuriComponent
-  onDragEnd={function (shownItems, hiddenItems) {
+  onFilter={function (shownItems, hiddenItems) {
     console.log(shownItems);
     console.log(hiddenItems);
   }}
@@ -1107,7 +1107,7 @@ Triggered when the `sort` is applied.
 
 ```jsx
 <MuuriComponent
-  onDragEnd={function (currentOrder, previousOrder) {
+  onSort={function (currentOrder, previousOrder) {
     console.log(currentOrder);
     console.log(previousOrder);
   }}


### PR DESCRIPTION
fix incorrect doc
Where it should have been onFilter (,onSort) was onDragEnd.